### PR TITLE
SG-29427: Fix Mac build and Shader

### DIFF
--- a/cmake/defaults/rv_options.cmake
+++ b/cmake/defaults/rv_options.cmake
@@ -12,7 +12,7 @@ OPTION(RV_SHOW_ALL_VARIABLES "Displays all build variables." ON)
 #
 # General build options
 
-OPTION(RV_USE_OCIO_OPENEXR "Uses OpenColorIO's own copy of OpenEXR." ON)
+OPTION(RV_USE_OCIO_OPENEXR "Uses OpenColorIO's own copy of OpenEXR." OFF)
 OPTION(RV_USE_OCIO_YAML_CPP "Uses OpenColorIO's own copy of Yaml-Cpp." ON)
 
 SET(RV_DEPS_BASE_DIR

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -58,11 +58,13 @@ INCLUDE(doctest)
 INCLUDE(jpegturbo) # jpegturbo huge advantage over jpeg is that it does come with CMake support!
 INCLUDE(png)
 INCLUDE(tiff)  # depends on jpeg, jpegturbo
+ADD_SUBDIRECTORY(../../src/pub/lcms src/pub/lcms) # required by raw
 INCLUDE(raw)   # depends on jpeg, zlib
 INCLUDE(openjpeg) # depends on zlib, tiff, png
 INCLUDE(webp)
 INCLUDE(ocio)
 INCLUDE(openexr)  # depends on ocio
+ADD_SUBDIRECTORY(../../src/pub/freetype src/pub/freetype) # required by oiio
 INCLUDE(oiio)  # depends on openexr and most image formats above and ocio (actually, there's inter-dependency between ocio and oiio)
 IF(RV_USE_OCIO_YAML_CPP)
   INCLUDE(yaml-cpp)  # depends on OCIO

--- a/cmake/dependencies/imath.cmake
+++ b/cmake/dependencies/imath.cmake
@@ -29,6 +29,7 @@ SET(_install_dir
 SET(_include_dir
     ${_install_dir}/include/Imath
 )
+SET(RV_DEPS_IMATH_ROOT_DIR ${_install_dir})
 
 SET(_make_command
     make

--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -106,13 +106,11 @@ IF(NOT RV_USE_OCIO_OPENEXR)
   #LIST(APPEND _configure_options "-DOpenEXR_ROOT=${RV_DEPS_OPENEXR_ROOT_DIR}")
 ENDIF()
 
-#MESSAGE(FATAL_ERROR "RV_DEPS_IMATH_ROOT_DIR='${RV_DEPS_IMATH_ROOT_DIR}'")
-#GET_TARGET_PROPERTY(_imath_library Imath::Imath IMPORTED_LOCATION)
-#GET_TARGET_PROPERTY(_imath_include_dir Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+GET_TARGET_PROPERTY(_imath_library Imath::Imath IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_imath_include_dir Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+LIST(APPEND _configure_options "-DImath_LIBRARY=${_imath_library}")
+LIST(APPEND _configure_options "-DImath_INCLUDE_DIR=${_imath_include_dir}/..")
 LIST(APPEND _configure_options "-DImath_ROOT=${RV_DEPS_IMATH_ROOT_DIR}")
-#LIST(APPEND _configure_options "-DImath_DIR=${RV_DEPS_IMATH_ROOT_DIR}")
-#LIST(APPEND _configure_options "-DIMATH_LIBRARY=${_imath_library}")
-#LIST(APPEND _configure_options "-DIMATH_INCLUDE_DIR=${_imath_include_dir}")
 
 MESSAGE(WARNING "OCIO: We would like to compile against own OIIO, but OIIO uses OCIO's own OpenEXR")
 IF(FALSE)
@@ -135,6 +133,8 @@ LIST(APPEND _configure_options "-DOPENIMAGEIO_VERSION=${RV_DEPS_OIIO_VERSION}")
 LIST(APPEND _configure_options "-DOPENIMAGEIO_ROOT_DIR=${_oiio_install_dir}")
 
 LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
+
+LIST(APPEND _configure_options "-DOCIO_BUILD_APPS=OFF")
 
 MESSAGE(WARNING "TODO: ${_target}: figure out how to run tests???")
 EXTERNALPROJECT_ADD(
@@ -160,8 +160,8 @@ EXTERNALPROJECT_ADD(
 ADD_CUSTOM_COMMAND(
     TARGET ${_target}
     POST_BUILD
-    COMMENT "Copying PyOpenColorIO lib into '${_pyocio_dest_dir}'."
-    COMMAND ${CMAKE_COMMAND} -E copy ${_pyocio_lib} ${_pyocio_dest_dir}
+    COMMENT "Copying PyOpenColorIO lib into '${RV_STAGE_PLUGINS_PYTHON_DIR}'."
+    COMMAND ${CMAKE_COMMAND} -E copy ${_pyocio_lib} ${RV_STAGE_PLUGINS_PYTHON_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
 )
 

--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -27,6 +27,7 @@ LIST(APPEND _configure_options "-DBUILD_TESTING=OFF")
 LIST(APPEND _configure_options "-DUSE_PYTHON=0")  # this on would requireextra pybind11 package
 #LIST(APPEND _configure_options "-DOpenColorIO_ROOT=${RV_DEPS_OCIO_INSTALL_DIR}")
 LIST(APPEND _configure_options "-DUSE_OCIO=0")
+LIST(APPEND _configure_options "-DUSE_GIF=OFF")
 
 #GET_TARGET_PROPERTY(_boost_include_dir Boost::headers INTERFACE_INCLUDE_DIRECTORIES)
 LIST(APPEND _configure_options "-DBoost_ROOT=${RV_DEPS_BOOST_ROOT_DIR}")
@@ -36,7 +37,12 @@ LIST(APPEND _configure_options "-DOpenEXR_ROOT=${RV_DEPS_OPENEXR_ROOT_DIR}")
 #LIST(APPEND _configure_options "-DOPENEXR_LIBRARY=${_openexr_library}")
 #LIST(APPEND _configure_options "-DOPENEXR_INCLUDE_DIR=${_openexr_include_dir}")
 
-LIST(APPEND _configure_options "-DImath_ROOT=${RV_DEPS_IMATH_ROOT_DIR}")
+GET_TARGET_PROPERTY(_imath_library Imath::Imath IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_imath_include_dir Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+LIST(APPEND _configure_options "-DImath_LIBRARY=${_imath_library}")
+LIST(APPEND _configure_options "-DImath_INCLUDE_DIR=${_imath_include_dir}/..")
+GET_FILENAME_COMPONENT(_imath_library_path ${_imath_library} DIRECTORY)
+LIST(APPEND _configure_options "-DImath_DIR=${_imath_library_path}/cmake/Imath")
 
 GET_TARGET_PROPERTY(_png_library PNG::PNG IMPORTED_LOCATION)
 GET_TARGET_PROPERTY(_png_include_dir PNG::PNG INTERFACE_INCLUDE_DIRECTORIES)
@@ -54,13 +60,29 @@ LIST(APPEND _configure_options "-DJPEGTURBO_LIBRARY=${_jpegturbo_library}")
 LIST(APPEND _configure_options "-DJPEGTURBO_INCLUDE_DIR=${_jpegturbo_include_dir}")
 
 LIST(APPEND _configure_options "-DOpenJPEG_ROOT=${RV_DEPS_OPENJPEG_ROOT_DIR}")
+GET_TARGET_PROPERTY(_openjpeg_library OpenJpeg::OpenJpeg IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_openjpeg_include_dir OpenJpeg::OpenJpeg INTERFACE_INCLUDE_DIRECTORIES)
+LIST(APPEND _configure_options "-DOPENJPEG_OPENJP2_LIBRARY=${_openjpeg_library}")
+LIST(APPEND _configure_options "-DOPENJPEG_INCLUDE_DIR=${_openjpeg_include_dir}")
 
 GET_TARGET_PROPERTY(_tiff_library Tiff::Tiff IMPORTED_LOCATION)
 GET_TARGET_PROPERTY(_tiff_include_dir Tiff::Tiff INTERFACE_INCLUDE_DIRECTORIES)
 LIST(APPEND _configure_options "-DTIFF_LIBRARY=${_tiff_library}")
 LIST(APPEND _configure_options "-DTIFF_INCLUDE_DIR=${_tiff_include_dir}")
 
-LIST(APPEND _configure_options "-DFFmpeg_ROOT=${RV_DEPS_FFMPEG_ROOT_DIR}")
+GET_TARGET_PROPERTY(_ffmpeg_include_dir ffmpeg::avcodec INTERFACE_INCLUDE_DIRECTORIES)
+GET_TARGET_PROPERTY(_ffmpeg_libavcodec ffmpeg::avcodec IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_ffmpeg_libavformat ffmpeg::avformat IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_ffmpeg_libavutil ffmpeg::avutil IMPORTED_LOCATION)
+GET_TARGET_PROPERTY(_ffmpeg_libswscale ffmpeg::swscale IMPORTED_LOCATION)
+LIST(APPEND _configure_options "-DFFMPEG_INCLUDE_DIR=${_ffmpeg_include_dir}")
+LIST(APPEND _configure_options "-DFFMPEG_INCLUDES=${_ffmpeg_include_dir}")
+LIST(APPEND _configure_options "-DFFMPEG_AVCODEC_INCLUDE_DIR=${_ffmpeg_include_dir}")
+LIST(APPEND _configure_options "-DFFMPEG_LIBRARIES=${_ffmpeg_libavcodec} ${_ffmpeg_libavformat} ${_ffmpeg_libavutil} ${_ffmpeg_libswscale}")
+LIST(APPEND _configure_options "-DFFMPEG_LIBAVCODEC=${_ffmpeg_libavcodec}")
+LIST(APPEND _configure_options "-DFFMPEG_LIBAVFORMAT=${_ffmpeg_libavformat}")
+LIST(APPEND _configure_options "-DFFMPEG_LIBAVUTIL=${_ffmpeg_libavutil}")
+LIST(APPEND _configure_options "-DFFMPEG_LIBSWSCALE=${_ffmpeg_libswscale}")
 
 IF(RV_TARGET_LINUX)
   MESSAGE(STATUS "Building OpenImageIO using system's freetype library.")
@@ -100,7 +122,7 @@ EXTERNALPROJECT_ADD( ${_target}
   SOURCE_DIR ${_source_dir}
   BINARY_DIR ${_build_dir}
   INSTALL_DIR ${_install_dir}
-    DEPENDS ${_depends_freetype} jpeg-turbo::jpeg Tiff::Tiff RV_DEPS_OCIO OpenEXR::OpenEXR OpenJpeg::OpenJpeg jpeg-turbo::turbojpeg PNG::PNG Boost::headers Boost::thread Boost::filesystem Imath::Imath Webp::Webp Raw::Raw ffmpeg::swresample ffmpeg::swscale ffmpeg::avcodec ffmpeg::swresample ZLIB::ZLIB
+    DEPENDS ${_depends_freetype} jpeg-turbo::jpeg Tiff::Tiff RV_DEPS_OCIO OpenEXR::OpenEXR RV_DEPS_OPENJPEG jpeg-turbo::turbojpeg PNG::PNG Boost::headers Boost::thread Boost::filesystem Imath::Imath Webp::Webp Raw::Raw ffmpeg::swresample ffmpeg::swscale ffmpeg::avcodec ffmpeg::swresample ZLIB::ZLIB
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
     BUILD_COMMAND ${_make_command} -j${_cpu_count} -v
     INSTALL_COMMAND ${_make_command} install

--- a/cmake/dependencies/openjpeg.cmake
+++ b/cmake/dependencies/openjpeg.cmake
@@ -67,8 +67,8 @@ RV_COPY_LIB_BIN_FOLDERS()
 
 ADD_DEPENDENCIES(dependencies ${_target}-stage-target)
 
-add_library(OpenJpeg::OpenJpeg SHARED IMPORTED GLOBAL)
-set_property(
+ADD_LIBRARY(OpenJpeg::OpenJpeg SHARED IMPORTED GLOBAL)
+SET_PROPERTY(
     TARGET OpenJpeg::OpenJpeg
     PROPERTY IMPORTED_LOCATION ${_libpath}
 )

--- a/cmake/dependencies/raw.cmake
+++ b/cmake/dependencies/raw.cmake
@@ -29,7 +29,11 @@ RV_MAKE_STANDARD_LIB_NAME("raw" "23" "SHARED" "")
 # The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
 SET(_configure_options "")  # Overrides defaults set in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
 LIST(APPEND _configure_options "--prefix=${_install_dir}")
-LIST(APPEND _configure_options "--enable-lcms")  # The lcms library was linked against in our legacy build system.
+LIST(APPEND _configure_options "--enable-lcms")
+
+GET_TARGET_PROPERTY(_lcms_include_dir lcms INTERFACE_INCLUDE_DIRECTORIES)
+SET(_lcms2_flags "-I${_lcms_include_dir}") 
+SET(_lcms2_libs "-L${RV_STAGE_LIB_DIR} -llcms") 
 
 EXTERNALPROJECT_ADD(
   ${_target}
@@ -41,10 +45,10 @@ EXTERNALPROJECT_ADD(
   SOURCE_DIR ${_source_dir}
   BINARY_DIR ${_build_dir}
   INSTALL_DIR ${_install_dir}
-  #DEPENDS ZLIB::ZLIB lcms 
-  DEPENDS ZLIB::ZLIB
-  CONFIGURE_COMMAND ${_configure_command} ${_configure_options}
-  BUILD_COMMAND ${_make_command} -j${_cpu_count} -v
+  DEPENDS ZLIB::ZLIB lcms
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env LCMS2_CFLAGS='${_lcms2_flags}' 
+  ${CMAKE_COMMAND} -E env LCMS2_LIBS='${_lcms2_libs}'
+  ${_configure_command} ${_configure_options} BUILD_COMMAND ${_make_command} -j${_cpu_count} -v
   INSTALL_COMMAND ${_make_command} install
   BUILD_IN_SOURCE FALSE
   BUILD_ALWAYS FALSE

--- a/cmake/dependencies/webp.cmake
+++ b/cmake/dependencies/webp.cmake
@@ -43,6 +43,9 @@ GET_TARGET_PROPERTY(_tiff_include_dir Tiff::Tiff INTERFACE_INCLUDE_DIRECTORIES)
 LIST(APPEND _configure_options "-DTIFF_LIBRARY=${_tiff_library}")
 LIST(APPEND _configure_options "-DTIFF_INCLUDE_DIR=${_tiff_include_dir}")
 
+LIST(APPEND _configure_options "-DWEBP_BUILD_GIF2WEBP=OFF")
+LIST(APPEND _configure_options "-DWEBP_BUILD_ANIM_UTILS=OFF")
+
 EXTERNALPROJECT_ADD(
   ${_target}
   URL ${_download_url}

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -14,6 +14,7 @@
 #include <OpenColorIO/OpenColorIO.h>
 #include <boost/functional/hash.hpp>
 #include <algorithm>
+#include <regex>
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -38,10 +39,8 @@ struct OCIOState
 };
 
 namespace {
-// The OCIO::GPU_LANGUAGE_UNKNOWN no longer exists
-// and the value of zero is used by Nvidia Cg shader
-#define GPU_LANGUAGE_UNKNOWN -1
-OCIO::GpuLanguage GPULanguage = (OCIO::GpuLanguage)GPU_LANGUAGE_UNKNOWN;
+#define GPU_LANGUAGE_UNKNOWN OCIO::GpuLanguage::GPU_LANGUAGE_CG
+OCIO::GpuLanguage GPULanguage = GPU_LANGUAGE_UNKNOWN;
 }
 
 string
@@ -119,8 +118,7 @@ OCIOIPNode::OCIOIPNode(const string& name,
 
         if (major == 1 && minor < 30)
         {
-            //GPULanguage = OCIO::GPU_LANGUAGE_GLSL_1_0;
-            // The lowest available value in newer OCIO is now 1.2
+            // Note: 1.2 is currently the lowest available value in OCIO
             GPULanguage = OCIO::GPU_LANGUAGE_GLSL_1_2;
         }
         else
@@ -154,7 +152,7 @@ OCIOIPNode::updateConfig()
     catch (std::exception& exc)
     {
         delete m_state;
-        cout << "ERROR: OCIOIPNode updateConfig caught: " << exc.what() << endl;
+        cerr << "ERROR: OCIOIPNode updateConfig caught: " << exc.what() << endl;
         m_state = 0;
         throw;
     }
@@ -224,6 +222,19 @@ shaderLegal(const string& s)
     transform(s.begin(), s.end(), ns.begin(), op_shaderLegal);
 
     return ns;
+}
+
+// Add the 3D LUT uniform as a shader function parameter to leverage RV's current 
+// shader variables binding mechanism which rely on shader variables being passed 
+// as function arguments for all its shaders.
+// Note that the OCIOv2 generated shader no longer passes the LUTs as function 
+// arguments.
+void 
+shaderAdd3DLutAsParameter(std::string& inout_glsl, const std::string& lutSamplerName)
+{
+    const std::string from = "vec4 inPixel";
+    std::string to = from + std::string(", sampler3D ") + lutSamplerName;
+    inout_glsl = std::regex_replace( inout_glsl, std::regex(from), to );
 }
 
 };
@@ -326,7 +337,7 @@ OCIOIPNode::evaluate(const Context& context)
             //
 
             OCIO::LookTransformRcPtr   transform = OCIO::LookTransform::Create();
-            OCIO::TransformDirection   direction;
+            OCIO::TransformDirection   direction = OCIO::TRANSFORM_DIR_FORWARD;
             string                     looksName = stringProp("ocio_look.look", "");
             string                     outName   = stringProp("ocio_look.outColorSpace", m_state->linear);
             bool                       reverse   = intProp("ocio_look.direction", 0) == 1;
@@ -363,12 +374,10 @@ OCIOIPNode::evaluate(const Context& context)
             //
 
             OCIO::DisplayViewTransformRcPtr transform = OCIO::DisplayViewTransform::Create();
-            string                      display   = stringProp("ocio_display.display", "");
-            string                      view      = stringProp("ocio_display.view", "");
+            string                          display   = stringProp("ocio_display.display", "");
+            string                          view      = stringProp("ocio_display.view", "");
 
-#if 0
-            transform->setInputColorSpaceName(inName.c_str());
-#endif
+            transform->setSrc(inName.c_str());
             transform->setDisplay(display.c_str());
             transform->setView(view.c_str());
             processor = m_state->config->getProcessor(m_state->context, 
@@ -378,48 +387,31 @@ OCIOIPNode::evaluate(const Context& context)
             size_t hashValue = string_hash(inName + display + view);
             shaderName << "OCIO_d_" << shaderLegal(display) << "_" << shaderLegal(view) << "_" << name() << "_" << hex << hashValue;
         }
-#if 0
-        OCIO::GpuShaderDesc shaderDesc;
-        shaderDesc.setLanguage(GPULanguage);
-        shaderDesc.setFunctionName(shaderName.str().c_str());
-        shaderDesc.setLut3DEdgeLen(lutSize);
+
+        OCIO::ConstGPUProcessorRcPtr legacyGPUProcessor = processor->getOptimizedLegacyGPUProcessor(OCIO::OPTIMIZATION_NONE, lutSize);
+        OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(GPULanguage);
+        shaderDesc->setFunctionName(shaderName.str().c_str());
+
+        // Fills the shaderDesc from the proc.
+        legacyGPUProcessor->extractGpuShaderInfo(shaderDesc);
+
+        // When using getOptimizedLegacyGPUProcessor, getNumTextures(), which is for any Lut1Ds, 
+        // should always be 0 and getNum3DTextures() should never be more than 1/
+        if (shaderDesc->getNumTextures() != 0 && shaderDesc->getNum3DTextures() > 1)
+        {
+            cerr << "OCIO IP Node error: " << "Unknown case about number of textures in Nuke node transform." 
+                 << "num text: " << shaderDesc->getNumTextures() 
+                 << ", num 3d tex: " << shaderDesc->getNum3DTextures()
+                 << endl;
+            return nullptr;
+        }
 
         pthread_mutex_lock(&m_lock);
 
-        //
-        // The story so far: We always thought OCIO _always_ produced hw
-        // shading that required a 3D LUT of some kind.  This is (mostly) not
-        // true.
-        //
-        // The Processor holds 3 vectors of "Ops": those that happen before any
-        // LUT (m_gpuOpsHwPreProcess), those that must be implmented in a LUT
-        // (m_gpuOpsCpuLatticeProcess), and those that happen after the LUT
-        // (m_gpuOpsHwPostProcess).  These lists are created by
-        // PartitionGPUOps() and if all the incoming Ops are analytical (have
-        // direct GPU implementation) then all the ops will go into the first
-        // list and the others will be empty.  In this case, OCIO will not
-        // (need not) generate a 3D LUT at all.  AND the "3DLUT ID" generated
-        // by getGpuLut3DCacheID() will be "<NULL>".  As far as I can tell,
-        // there's no other way for calling code to tell that a 3DLUT is
-        // unnecessary
-        //
-        // BUT, there is hack in OCIO code (to prevent segfault, comment says)
-        // so that on Mac only, it _always_ generates a 3D LUT.  When the LUT
-        // is not necessary, it will be an identity LUT, although the ID is
-        // still "<NULL>".
-        //
-        // ALSO BUT, the shader that OCIO generates _always_ has LUT argument,
-        // whether it is going to use it or not.
-        //
-        // Now we only add a lut FB if one is needed; NOTE that core OCIO code
-        // has also been changed to support this (now it only produces a shader
-        // with a LUT parameter IF it needs one.
-        //
-
-        string lut3dCacheID  = processor->getGpuLut3DCacheID(shaderDesc);
-        string shaderCacheID = processor->getGpuShaderTextCacheID(shaderDesc);
-
-        if (m_state->lutID != lut3dCacheID)
+        string lut3dCacheID  = legacyGPUProcessor->getCacheID();
+        string shaderCacheID = lut3dCacheID;
+        if (m_state->lutID != lut3dCacheID && 1 == shaderDesc->getNum3DTextures())
         {
             if (m_lutfb)
             {
@@ -438,13 +430,31 @@ OCIOIPNode::evaluate(const Context& context)
                 channels[2] = "B";
 
                 m_lutfb = new TwkFB::FrameBuffer(FrameBuffer::NormalizedCoordinates,
-                                                 lutSize, lutSize, lutSize, 3, FrameBuffer::FLOAT, 
+                                                 lutSize, lutSize, lutSize, 3, FrameBuffer::FLOAT,
                                                  0, &channels, FrameBuffer::BOTTOMLEFT,
                                                  true);
 
 		        m_lutfb->staticRef();
                 m_lutfb->setIdentifier(lut3dCacheID);
-                processor->getGpuLut3D(m_lutfb->pixels<float>(), shaderDesc);
+
+                const char* tex_name = nullptr;
+                const char* sampler_name = nullptr;
+                unsigned int lut3DTexEdgeLen = 0;
+                OCIO::Interpolation lut3DInterpolation = OCIO::INTERP_BEST;
+                shaderDesc->get3DTexture(0, tex_name, sampler_name, lut3DTexEdgeLen, lut3DInterpolation);
+                m_lutSamplerName = sampler_name;
+
+                if (lut3DTexEdgeLen == lutSize)
+                {
+                    const float * temp = nullptr;
+                    shaderDesc->get3DTextureValues(0, temp);
+                    memcpy(m_lutfb->pixels<float>(), temp, 3*sizeof(float)*lutSize*lutSize*lutSize);
+                }                
+                else
+                {
+                    cerr << "ERROR: OCIONode: "<< name() << " - Expected 3D LUT Size = " << lutSize 
+                         << ", Found = " << lut3DTexEdgeLen << endl;
+                }
             }
             m_state->lutID = lut3dCacheID;
 
@@ -458,11 +468,16 @@ OCIOIPNode::evaluate(const Context& context)
         {
             if (m_state->function) m_state->function->retire();
 
-            ostringstream glsl;
-            glsl << processor->getGpuShaderText(shaderDesc);
+            string glsl(shaderDesc->getShaderText());
+
+            // Add the 3D LUT uniform as a shader function parameter if any
+            if (m_lutfb)
+            {
+                shaderAdd3DLutAsParameter(glsl, m_lutSamplerName);
+            }
 
             m_state->function = new Shader::Function(shaderName.str(), 
-                                                     glsl.str(),
+                                                     glsl,
                                                      Shader::Function::Color,
                                                      1);
             m_state->shaderID = shaderCacheID;
@@ -470,12 +485,12 @@ OCIOIPNode::evaluate(const Context& context)
             if (Shader::debuggingType() != Shader::NoDebugInfo)
             {
                 cerr << "OCIONode: " << name() << " new shaderID " << shaderCacheID << endl <<
-                        "OCIONode:     new Shader '" << shaderName.str() << "':" << endl << glsl.str() << endl;
+                        "OCIONode:     new Shader '" << shaderName.str() << "':" << endl << glsl << endl;
             }
         }
 
         pthread_mutex_unlock(&m_lock);
-#endif
+
         const Shader::Function* F = m_state->function;
         Shader::ArgumentVector args(F->parameters().size());
 
@@ -499,7 +514,7 @@ OCIOIPNode::evaluate(const Context& context)
     }
     catch (std::exception& exc)
     {
-        cout << "ERROR: OCIOIPNode: " << exc.what() << endl;
+        cerr << "ERROR: OCIOIPNode: " << exc.what() << endl;
     }
 
     return image;

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -52,6 +52,7 @@ class OCIOIPNode : public IPNode
     StringProperty* m_configDescription;
     StringProperty* m_configWorkingDir;
     FrameBuffer*    m_lutfb;
+    std::string     m_lutSamplerName;
     FrameBuffer*    m_prelutfb;
     OCIOState*      m_state;
     pthread_mutex_t m_lock;

--- a/src/plugins/rv-packages/ocio_source_setup/ocio_source_setup.py
+++ b/src/plugins/rv-packages/ocio_source_setup/ocio_source_setup.py
@@ -43,7 +43,7 @@ def ocio_node_from_media(config, node, default, media=None, attributes={}):
                 "context": {},
                 "properties": {
                     "ocio.function": "display",
-                    "ocio.inColorSpace": OCIO.Constants.ROLE_SCENE_LINEAR,
+                    "ocio.inColorSpace": OCIO.ROLE_SCENE_LINEAR,
                     "ocio_display.view": config.getDefaultView(display),
                     "ocio_display.display": display,
                 },
@@ -62,7 +62,7 @@ def ocio_node_from_media(config, node, default, media=None, attributes={}):
                     "properties": {
                         "ocio.function": "color",
                         "ocio.inColorSpace": inspace,
-                        "ocio_color.outColorSpace": OCIO.Constants.ROLE_SCENE_LINEAR,
+                        "ocio_color.outColorSpace": OCIO.ROLE_SCENE_LINEAR,
                     },
                 },
                 {"nodeType": "RVLensWarp", "context": {}, "properties": {}},
@@ -78,7 +78,7 @@ def ocio_node_from_media(config, node, default, media=None, attributes={}):
         #      "context"    : {"SHOT" : os.environ.get("SHOT", "def123")}
         #      "properties" : {
         #          "ocio.function"     : "look",
-        #          "ocio.inColorSpace" : OCIO.Constants.ROLE_SCENE_LINEAR,
+        #          "ocio.inColorSpace" : OCIO.ROLE_SCENE_LINEAR,
         #          "ocio_look.look"    : "shot_specific_look"}}]
 
         look = attributes.get("default_setting", "")


### PR DESCRIPTION
SG-29427: Fix Mac build on Bernie's machine and fix OCIOv2 generated shader

### Summarize your change.

About the fixes for the build:
I made sure to only take the changes absolutely necessary to make the branch build on my mac.
I have listed every single error I encountered along with the fix  below.

About the fix for the OCIOv2 generated shader:
I started with your OCIOIPNode work from your babiin/OCIOv2_OCIOIpNode_IOoiio_use_JP2000 branch and then:
1. Fixed the initialization of the LUT TwkFB::FrameBuffer m_lutfb.
2. Fixed the OCIOv2 generated shader.
The OCIOv2 generated shader no longer passes the LUTs as function arguments.

In the glsl code that OCIO v1 was generating, the 3D LUT was passed as a parameter:
vec4 OCIO_c_xyz16_2_scene_linear_sourceGroup000000_tolinPipeline_0_7205fe1249d30ba6(vec4 inPixel
,    sampler3D lut3d) 
{...

In the OCIO v2 shader generated code, the 3D LUT is NOT passed by parameter:
vec4 OCIO_c_xyz16_2_scene_linear_sourceGroup000000_tolinPipeline_0_7205fe1249d30ba6(vec4 inPixel)
{...

This was breaking the shader parameter binding mechanism implemented in RV.
Note that I checked and every single shader used in RV has its variables bound by parameter.
To make this work generically would require some significant refactoring of the lib/ip/IPCore/IPCore/ShaderFunction.h.cpp code which parses the shader GLSL and compiles a list of Shader::Function::m_parameters.

    Shader::Function(const std::string& name, 
             const std::string& glsl,
             Type type,
             size_t numFetchesApprox = 0,
             const std::string& doc="");

There is a Shader::Function::m_globals member but it is neither initialized nor used. 

What I propose in this PR is to simply artificially add the 3D LUT as a parameter to the OCIOv2 generated shader.
This way the standard parameter binding in RV can do its work.
This is what shaderAdd3DLutAsParameter() does.

### Describe the reason for the change.

The build of that development branch was failing on my Mac because I have a bunch of brew installed packages which are arm based (NOT Intel) which was breaking the build.

Additionally the OCIOv2 implementation was not working as expected (black output).

### Describe what you have tested and on which operating system.
Tested a build from scratch on my MacBook Pro M1 (16-inch, 2021) running macOS Monterey 12.6.3.
Also validated that the OCIO works as expected.

### Add a list of changes, and note any that might need special attention during the review.

---

rvcfg Error:

---
CMake Error at cmake/dependencies/oiio.cmake:70 (GET_TARGET_PROPERTY):
  get_target_property() called with non-existent target "freetype".
Call Stack (most recent call first):
  cmake/dependencies/CMakeLists.txt:66 (INCLUDE)


CMake Error at cmake/dependencies/oiio.cmake:71 (GET_TARGET_PROPERTY):
  get_target_property() called with non-existent target "freetype".
Call Stack (most recent call first):
  cmake/dependencies/CMakeLists.txt:66 (INCLUDE)


CMake Error at /opt/homebrew/lib/python3.10/site-packages/cmake/data/share/cmake-3.25/Modules/ExternalProject.cmake:3480 (get_property):
  get_property could not find TARGET freetype.  Perhaps it has not yet been
  created.
Call Stack (most recent call first):
  /opt/homebrew/lib/python3.10/site-packages/cmake/data/share/cmake-3.25/Modules/ExternalProject.cmake:3662 (_ep_get_file_deps)
  /opt/homebrew/lib/python3.10/site-packages/cmake/data/share/cmake-3.25/Modules/ExternalProject.cmake:4188 (_ep_add_configure_command)
  cmake/dependencies/oiio.cmake:94 (EXTERNALPROJECT_ADD)
  cmake/dependencies/CMakeLists.txt:66 (INCLUDE)


----


Fix in:

---

cmake/dependencies/CMakeLists.txt

ADD_SUBDIRECTORY(../../src/pub/freetype src/pub/freetype) # required by oiio

-----


rvbuild Error:


----

[ 87%] Linking C executable gif2webp
ld: warning: ignoring file /opt/homebrew/lib/libgif.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture x86_64:
  "_DGifCloseFile", referenced from:
      _main in gif2webp.c.o
  "_DGifGetExtension", referenced from:
      _main in gif2webp.c.o
  "_DGifGetExtensionNext", referenced from:
      _main in gif2webp.c.o
      _GIFReadLoopCount in gifdec.c.o
      _GIFReadMetadata in gifdec.c.o
  "_DGifGetImageDesc", referenced from:
      _main in gif2webp.c.o
  "_DGifGetLine", referenced from:
      _GIFReadFrame in gifdec.c.o
  "_DGifGetRecordType", referenced from:
      _main in gif2webp.c.o
  "_DGifOpenFileHandle", referenced from:
      _main in gif2webp.c.o
  "_DGifOpenFileName", referenced from:
      _main in gif2webp.c.o
  "_GifErrorString", referenced from:
      _GIFDisplayError in gifdec.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [gif2webp] Error 1
make[1]: *** [CMakeFiles/gif2webp.dir/all] Error 2


----

Fix in:

---

/cmake/dependencies/webp.cmake

LIST(APPEND _configure_options "-DWEBP_BUILD_GIF2WEBP=OFF")
LIST(APPEND _configure_options "-DWEBP_BUILD_ANIM_UTILS=OFF")


---

rvbuild Error:

---

ld: warning: ignoring file /opt/homebrew/Cellar/little-cms2/2.14/lib/liblcms2.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture x86_64:
  "_cmsCloseProfile", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsCreateTransform", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsCreate_sRGBProfile", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsDeleteTransform", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsDoTransform", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsOpenProfileFromFile", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
  "_cmsOpenProfileFromMem", referenced from:
      LibRaw::apply_profile(char const*, char const*) in apply_profile.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lib/libraw.la] Error 1


---

Fix in:

cmake/dependencies/raw.cmake
cmake/dependencies/CMakeLists.txt

---

rvbuild error:

---

[ 40%] Linking CXX shared library libOpenColorIO.dylib
ld: warning: ignoring file /opt/homebrew/Cellar/imath/3.1.7/lib/libImath.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture x86_64:
  "_imath_half_to_float_table", referenced from:
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)1>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)2>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)3>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)5>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)7>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::BitDepthCast<(OpenColorIO_v2_2::BitDepth)7, (OpenColorIO_v2_2::BitDepth)8>::apply(void const*, void*, long) const in CPUProcessor.cpp.o
      OpenColorIO_v2_2::(anonymous namespace)::LocalFileFormat::read(std::__1::basic_istream<char, std::__1::char_traits<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, OpenColorIO_v2_2::Interpolation) const in FileFormatDiscreet1DL.cpp.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/OpenColorIO/libOpenColorIO.2.2.1.dylib] Error 1
make[1]: *** [src/OpenColorIO/CMakeFiles/OpenColorIO.dir/all] Error 2


---

Fix in:

---

cmake/dependencies/imath.cmake
cmake/dependencies/ocio.cmake

---

rvbuild error:

---

/Users/labergb/openrv_ociov2/OpenRV/src/lib/image/TwkFB/Operations.cpp:12:10: fatal error: 'ImfRgbaYca.h' file not found
#include <ImfRgbaYca.h>
         ^~~~~~~~~~~~~~
2 warnings and 1 error generated.

---
Fix in:
---

cmake/defaults/rv_options.cmake

---

rvbuild error:

---

[  9%] Linking CXX shared library ../../lib/libOpenImageIO_Util.dylib
ld: warning: ignoring file /opt/homebrew/lib/libImath-3_1.30.0.1.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture x86_64:
  "_imath_half_to_float_table", referenced from:
      void OpenImageIO_v2_4::convert_type<Imath_3_1::half, float>(Imath_3_1::half const*, float*, unsigned long, float, float) in fmath.cpp.o
      OpenImageIO_v2_4::ParamValue::get_string_indexed(int) const in paramlist.cpp.o
      OpenImageIO_v2_4::tostring(OpenImageIO_v2_4::TypeDesc, void const*, OpenImageIO_v2_4::tostring_formatting const&) in typedesc.cpp.o
      OpenImageIO_v2_4::convert_type(OpenImageIO_v2_4::TypeDesc, void const*, OpenImageIO_v2_4::TypeDesc, void*, int) in typedesc.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libOpenImageIO_Util.2.4.6.dylib] Error 1
make[1]: *** [src/libutil/CMakeFiles/OpenImageIO_Util.dir/all] Error 2

---

Fix in:

---

cmake/dependencies/oiio.cmake

---

rvbuild error:

---

[ 65%] Linking CXX shared library ../../lib/libOpenImageIO.dylib
ld: warning: ignoring file /opt/homebrew/lib/libfreetype.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
ld: warning: ignoring file /opt/homebrew/lib/libfreetype.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture x86_64:
  "_FT_Done_Face", referenced from:
      OpenImageIO_v2_4::ImageBufAlgo::text_size(OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >) in imagebufalgo_draw.cpp.o
      OpenImageIO_v2_4::ImageBufAlgo::render_text(OpenImageIO_v2_4::ImageBuf&, int, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, OpenImageIO_v2_4::span<float const, -1l>, OpenImageIO_v2_4::ImageBufAlgo::TextAlignX, OpenImageIO_v2_4::ImageBufAlgo::TextAlignY, int, OpenImageIO_v2_4::ROI, int) in imagebufalgo_draw.cpp.o
  "_FT_Init_FreeType", referenced from:
      OpenImageIO_v2_4::(anonymous namespace)::resolve_font(OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) in imagebufalgo_draw.cpp.o
  "_FT_Load_Char", referenced from:
      OpenImageIO_v2_4::ImageBufAlgo::text_size(OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >) in imagebufalgo_draw.cpp.o
      OpenImageIO_v2_4::ImageBufAlgo::render_text(OpenImageIO_v2_4::ImageBuf&, int, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, OpenImageIO_v2_4::span<float const, -1l>, OpenImageIO_v2_4::ImageBufAlgo::TextAlignX, OpenImageIO_v2_4::ImageBufAlgo::TextAlignY, int, OpenImageIO_v2_4::ROI, int) in imagebufalgo_draw.cpp.o
  "_FT_New_Face", referenced from:
      OpenImageIO_v2_4::ImageBufAlgo::text_size(OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >) in imagebufalgo_draw.cpp.o
      OpenImageIO_v2_4::ImageBufAlgo::render_text(OpenImageIO_v2_4::ImageBuf&, int, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, OpenImageIO_v2_4::span<float const, -1l>, OpenImageIO_v2_4::ImageBufAlgo::TextAlignX, OpenImageIO_v2_4::ImageBufAlgo::TextAlignY, int, OpenImageIO_v2_4::ROI, int) in imagebufalgo_draw.cpp.o
  "_FT_Set_Pixel_Sizes", referenced from:
      OpenImageIO_v2_4::ImageBufAlgo::text_size(OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >) in imagebufalgo_draw.cpp.o
      OpenImageIO_v2_4::ImageBufAlgo::render_text(OpenImageIO_v2_4::ImageBuf&, int, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, int, OpenImageIO_v2_4::basic_string_view<char, std::__1::char_traits<char> >, OpenImageIO_v2_4::span<float const, -1l>, OpenImageIO_v2_4::ImageBufAlgo::TextAlignX, OpenImageIO_v2_4::ImageBufAlgo::TextAlignY, int, OpenImageIO_v2_4::ROI, int) in imagebufalgo_draw.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libOpenImageIO.2.4.6.dylib] Error 1
make[1]: *** [src/libOpenImageIO/CMakeFiles/OpenImageIO.dir/all] Error 2

---

Fix in:

----

pub/freetype/CMakeLists.txt

Added this:

  SET(_libpath
    ${RV_STAGE_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}freetype${CMAKE_STATIC_LIBRARY_SUFFIX}
  )

  SET_PROPERTY(
    TARGET ${_target}
    PROPERTY IMPORTED_LOCATION ${_libpath}
  )

