### PR TITLE
OCIO v2 Update on Linux Platform

### DIFF
--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -130,8 +130,11 @@ ENDIF()
 LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 
 IF(RV_TARGET_LINUX)
-  MESSAGE(WARNING "TODO: Temporary hack allowing OIIO's internal tools to find our librairies...")
-  SET(ENV{LD_LIBRARY_PATH ${RV_STAGE_LIB_DIR})
+  # OIIO's libUtils Tools & Tests USES a different Link Flags which is 'hidden' and isn't set by us.
+  LIST(APPEND _configure_options
+    "-DOIIO_BUILD_TOOLS=OFF"
+    "-DOIIO_BUILD_TESTS=OFF"
+  )
 ENDIF()
 
 IF(RV_TARGET_WINDOWS)

--- a/cmake/dependencies/tiff.cmake
+++ b/cmake/dependencies/tiff.cmake
@@ -22,12 +22,8 @@ SET(_download_hash
 )
 
 IF(NOT RV_TARGET_WINDOWS)
-  IF(RV_TARGET_DARWIN)
-    # Mac: Use the unversionned .dylib LINK which points to the proper file (which has a diff version number)
+    # Mac/Linux: Use the unversionned .dylib.so LINK which points to the proper file (which has a diff version number)
     RV_MAKE_STANDARD_LIB_NAME("tiff" "" "SHARED" "d")
-  ELSE()
-    RV_MAKE_STANDARD_LIB_NAME("tiff" "${_version}" "SHARED" "d")
-  ENDIF()
 ELSE()
   # The current CMake build code via NMake doesn't create a Debug lib named "libtiffd.lib"
   RV_MAKE_STANDARD_LIB_NAME("libtiff" "${_version}" "SHARED" "")
@@ -147,7 +143,7 @@ ELSE()
     INSTALL_DIR ${_install_dir}
     DEPENDS ZLIB::ZLIB jpeg-turbo::jpeg
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
-    BUILD_COMMAND ${_make_command} -j${_cpu_count} -v
+    BUILD_COMMAND ${_make_command} -j${_cpu_count}
     INSTALL_COMMAND ${_make_command} install
     BUILD_IN_SOURCE FALSE
     BUILD_ALWAYS FALSE


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Disabling OIIO Tools and OIIO Tests to fix Linux build.

### Describe the reason for the change.

Disabling OIIO Tools and tests since they do not have proper linked libraries and we cannot add them outside of OIIO CMake code Using the same lib macro than MacOS for Linux for TIFF

### Describe what you have tested and on which operating system.

Tested on Linux Rocky 8. Windows is not affected for this change. This change is trivial for Mac as there's only a bad CMake flag that is now removed.

### Add a list of changes, and note any that might need special attention during the review.

Disabling OIIO Tools and OIIO Tests on Linux since we cannot add missing Linking flags to pass missing Libs
Removing SET(ENV{xxx} ...) call on Linux since the Syntax (proper syntax on the left on this line)moreover, ENV{} is for the current CMake process and we build with external CMake processes with ExternalProject_Add
Removing -v from CMake Build call since for CMake '-v' is '--version' and not '--verbose' like 'make'.

### If possible, provide screenshots.