### PR TITLE
OCIO v2.2 update: fix OCIO freezes

### DIFF
--- a/src/lib/ip/IPCore/ShaderFunction.cpp
+++ b/src/lib/ip/IPCore/ShaderFunction.cpp
@@ -302,7 +302,7 @@ Function::releaseCompiledState() const
     {
         if (m_state->shader) glDeleteShader(m_state->shader);
         delete m_state;
-        m_state = 0;
+        m_state = nullptr;
     }
 }
 
@@ -1532,7 +1532,8 @@ Function::generateTestGLSL(bool gl2) const
 void
 Function::deleteRetired()
 {
-    for (FunctionVector::iterator i = m_retiredFunctions.begin(); i != m_retiredFunctions.end(); ++i)
+    auto last = std::unique(m_retiredFunctions.begin(), m_retiredFunctions.end());  // assumption an object cannot be added more than once non-consecutively (lifetime of objects)
+    for (FunctionVector::iterator i = m_retiredFunctions.begin(); i != last; ++i)
     {
         delete *i;
     }

--- a/src/lib/ip/OCIONodes/CMakeLists.txt
+++ b/src/lib/ip/OCIONodes/CMakeLists.txt
@@ -10,6 +10,8 @@ SET(_target
     "OCIONodes"
 )
 
+FIND_PACKAGE(Qt5 REQUIRED COMPONENTS Core)
+
 FILE(GLOB _sources *.c*)
 ADD_LIBRARY(
   ${_target} STATIC
@@ -24,7 +26,7 @@ TARGET_INCLUDE_DIRECTORIES(
 TARGET_LINK_LIBRARIES(
   ${_target}
   PUBLIC IPCore TwkFB
-  PRIVATE ocio::ocio TwkUtil
+  PRIVATE ocio::ocio TwkUtil Qt5::Core
 )
 
 IF(RV_TARGET_WINDOWS)

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -10,6 +10,7 @@
 #include <IPCore/IPImage.h>
 #include <IPCore/IPNode.h>
 #include <TwkFB/FrameBuffer.h>
+#include <QMutex>
 
 namespace IPCore {
 
@@ -55,7 +56,7 @@ class OCIOIPNode : public IPNode
     std::string     m_lutSamplerName;
     FrameBuffer*    m_prelutfb;
     OCIOState*      m_state;
-    pthread_mutex_t m_lock;
+    mutable QMutex  m_lock;
 };
 
 } // Rv


### PR DESCRIPTION
### Linked issues
[SG-31071]
[SG-31074]
[SG-31094]

### Fixing Code freezes in RV when using OCIO v2.2.

### Summarize your change.

Fixing freezes by unlock Mutex when a exception happens
Using QMutex to easily unlock when an exception happen by using Scope with QMutexLocker
Fixing double/multi deletes of Shader::Function when a Config is not found.

### Describe the reason for the change.

Fixing major issues using OCIO

### Describe what you have tested and on which operating system.

Tested exception robustness when OCIO name isn't the same as RV
Tested many OCIO CS configs to test underscore fix

### Add a list of changes, and note any that might need special attention during the review.

Removing duplicate function object addresses in retire vector before
destructing objects
Using QMutex instead of pthread_mutex to take advantage of obj scope
versus Exceptions leaking from Shader::Function ctor
Fixing unfound OCIO Colour Spaces by removing consecutive underscores as
OCIO removes them in their code
