### PR TITLE
OCIO v2.2 update: remove OpenCL from Linux

### DIFF
--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -252,11 +252,15 @@ IF(RV_TARGET_WINDOWS)
     ${_target}
     PRIVATE "-wd4355"
   )
-ELSE()
+ELSEIF(RV_TARGET_DARWIN)
   FIND_PACKAGE(OpenCL REQUIRED)
   TARGET_LINK_LIBRARIES(
     ${_target}
     PUBLIC OpenCL::OpenCL
+  )
+ELSE()
+  TARGET_LINK_LIBRARIES(
+    ${_target}
   )
 ENDIF()
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Removing OpenCL for Linux

### Summarize your change.

Removing OpenCL

### Describe the reason for the change.

Linux doesn't need it, it builds fine without it and up to using OCIO colour spaces, nothing fails.

### Describe what you have tested and on which operating system.

Built and used RV on Linux

### Add a list of changes, and note any that might need special attention during the review.

Removing OpenCL no issue found on Linux but Mac doesn't build without it
Darwin uses the same CMake code while Linux is now using bare bone Target_LINK_LIB


### If possible, provide screenshots.