### PR TITLE
Issue 162: update ocio v2 remove yaml opt and less fragile code

### DIFF
--- a/cmake/defaults/rv_options.cmake
+++ b/cmake/defaults/rv_options.cmake
@@ -9,11 +9,6 @@
 OPTION(RV_VERBOSE_INVOCATION "Show the compiler/link command invocation." OFF)
 OPTION(RV_SHOW_ALL_VARIABLES "Displays all build variables." ON)
 
-#
-# General build options
-
-OPTION(RV_USE_OCIO_YAML_CPP "Uses OpenColorIO's own copy of Yaml-Cpp." ON)  # IF OFF: the user must provide another yaml lib
-
 SET(RV_DEPS_BASE_DIR
     "${CMAKE_BINARY_DIR}"
     CACHE STRING "RV's 3rd party cache location."

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -60,18 +60,16 @@ INCLUDE(ffmpeg)
 INCLUDE(doctest)
 INCLUDE(jpegturbo) # jpegturbo huge advantage over jpeg is that it does come with CMake support!
 INCLUDE(png)
-INCLUDE(tiff)  # depends on jpeg, jpegturbo
+INCLUDE(tiff) # depends on jpeg, jpegturbo
 ADD_SUBDIRECTORY(../../src/pub/lcms src/pub/lcms) # required by raw
-INCLUDE(raw)   # depends on jpeg, zlib
+INCLUDE(raw) # depends on jpeg, zlib
 INCLUDE(openjpeg) # depends on zlib, tiff, png
 INCLUDE(webp)
 INCLUDE(openexr)
 INCLUDE(ocio)
 ADD_SUBDIRECTORY(../../src/pub/freetype src/pub/freetype) # required by oiio
-INCLUDE(oiio)  # depends on openexr and most image formats above and ocio (actually, there's inter-dependency between ocio and oiio)
-IF(RV_USE_OCIO_YAML_CPP)
-  INCLUDE(yaml-cpp)  # depends on OCIO
-ENDIF()
+INCLUDE(oiio) # depends on openexr and most image formats above and ocio (actually, there's inter-dependency between ocio and oiio)
+INCLUDE(yaml-cpp) # depends on OCIO
 
 LIST(REMOVE_DUPLICATES RV_DEPS_LIST)
 SET(RV_DEPS_LIST

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -61,12 +61,14 @@ INCLUDE(doctest)
 INCLUDE(jpegturbo) # jpegturbo huge advantage over jpeg is that it does come with CMake support!
 INCLUDE(png)
 INCLUDE(tiff) # depends on jpeg, jpegturbo
+# src/pub: lmcs: src/pub will be removed eventually, this path will needed to change.
 ADD_SUBDIRECTORY(../../src/pub/lcms src/pub/lcms) # required by raw
 INCLUDE(raw) # depends on jpeg, zlib
 INCLUDE(openjpeg) # depends on zlib, tiff, png
 INCLUDE(webp)
 INCLUDE(openexr)
 INCLUDE(ocio)
+# src/pub: freetype: src/pub will be removed eventually, this path will needed to change.
 ADD_SUBDIRECTORY(../../src/pub/freetype src/pub/freetype) # required by oiio
 INCLUDE(oiio) # depends on openexr and most image formats above and ocio (actually, there's inter-dependency between ocio and oiio)
 INCLUDE(yaml-cpp) # depends on OCIO

--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -4,28 +4,35 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Build instructions:
-#   https://opencolorio.readthedocs.io/en/latest/quick_start/installation.html#building-from-source
+# Build instructions: https://opencolorio.readthedocs.io/en/latest/quick_start/installation.html#building-from-source
 #
 
 INCLUDE(ProcessorCount) # require CMake 3.15+
 PROCESSORCOUNT(_cpu_count)
 
-RV_CREATE_STANDARD_DEPS_VARIABLES( "RV_DEPS_OCIO" "2.2.1" "make" "")
+RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OCIO" "2.2.1" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
 # The folder OCIO is building its own dependencies
-SET(RV_DEPS_OCIO_DIST_DIR ${_build_dir}/ext/dist)
+SET(RV_DEPS_OCIO_DIST_DIR
+    ${_build_dir}/ext/dist
+)
 
 IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")
-    # Here the postfix is "d" and not "_d": the postfix inside OCIO is: "d".
-    SET(_ocio_debug_postfix "d")
-    MESSAGE(DEBUG "Using debug postfix: '${_ocio_debug_postfix}'")
+  # Here the postfix is "d" and not "_d": the postfix inside OCIO is: "d".
+  SET(_ocio_debug_postfix
+      "d"
+  )
+  MESSAGE(DEBUG "Using debug postfix: '${_ocio_debug_postfix}'")
 ELSE()
-    SET(_ocio_debug_postfix "")
+  SET(_ocio_debug_postfix
+      ""
+  )
 ENDIF()
 
-SET(_download_hash "372d6982cf01818a21a12f9628701a91")
+SET(_download_hash
+    "372d6982cf01818a21a12f9628701a91"
+)
 
 SET(_download_url
     "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v${_version}.tar.gz"
@@ -35,53 +42,63 @@ SET(_download_url
 RV_MAKE_STANDARD_LIB_NAME("OpenColorIO" "${_version}" "SHARED" "")
 
 IF(RV_TARGET_WINDOWS)
-  SET(_byproducts "")   # Empty out the List as it has the wrong DLL name: it doesn't have the version suffix
-  SET(_ocio_win_sharedlibname OpenColorIO_2_2.dll)
-  SET(_ocio_win_sharedlib_path ${_bin_dir}/${_ocio_win_sharedlibname})
+  SET(_byproducts
+      ""
+  ) # Empty out the List as it has the wrong DLL name: it doesn't have the version suffix
+  SET(_ocio_win_sharedlibname
+      OpenColorIO_2_2.dll
+  )
+  SET(_ocio_win_sharedlib_path
+      ${_bin_dir}/${_ocio_win_sharedlibname}
+  )
   LIST(APPEND _byproducts ${_ocio_win_sharedlib_path})
 ENDIF()
-# 
-# Also add OpenExr libraries to _byproduct
-#
-SET(_iex_name "Iex-3_1")
-SET(_ilmthread_name "IlmThread-3_1")
-SET(_openexrcore_name "OpenEXR-3_1")
-SET(_lib_type STATIC)
+
 IF(RV_TARGET_WINDOWS)
-  SET(_ociolib_dir "${RV_DEPS_OCIO_DIST_DIR}/lib")
-  SET(_iex_implib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_ilmthread_name}${RV_DEBUG_POSTFIX}.lib")
-  SET(_openexr_implib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_iex_name}${RV_DEBUG_POSTFIX}.lib")
-  SET(_ilmthread_implib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_openexrcore_name}${RV_DEBUG_POSTFIX}.lib")
+  SET(_ociolib_dir
+      "${RV_DEPS_OCIO_DIST_DIR}/lib"
+  )
 ENDIF()
 IF(RV_TARGET_LINUX)
-  SET(_ociolib_dir "${RV_DEPS_OCIO_DIST_DIR}/lib64")
+  SET(_ociolib_dir
+      "${RV_DEPS_OCIO_DIST_DIR}/lib64"
+  )
 ELSE()
-  SET(_ociolib_dir "${RV_DEPS_OCIO_DIST_DIR}/lib")
+  SET(_ociolib_dir
+      "${RV_DEPS_OCIO_DIST_DIR}/lib"
+  )
 ENDIF()
-
-SET(_ilmthread_lib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_ilmthread_name}${RV_DEBUG_POSTFIX}${CMAKE_${_lib_type}_LIBRARY_SUFFIX}")
-SET( _iex_lib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_iex_name}${RV_DEBUG_POSTFIX}${CMAKE_${_lib_type}_LIBRARY_SUFFIX}")
-SET(_openexr_lib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}${_openexrcore_name}${RV_DEBUG_POSTFIX}${CMAKE_${_lib_type}_LIBRARY_SUFFIX}")
-LIST(APPEND _byproducts "${_ilmthread_lib}")
-LIST(APPEND _byproducts "${_iex_lib}")
-LIST(APPEND _byproducts "${_openexr_lib}")
 
 #
 # Now, also add yaml-cpp as by-product
-SET(_yaml_cpp_lib "${_ociolib_dir}/${CMAKE_${_lib_type}_LIBRARY_PREFIX}yaml-cpp${_ocio_debug_postfix}${CMAKE_${_lib_type}_LIBRARY_SUFFIX}")
+SET(_yaml_cpp_lib
+    "${_ociolib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}yaml-cpp${_ocio_debug_postfix}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)
 LIST(APPEND _byproducts "${_yaml_cpp_lib}")
 
 #
 # and finally the PyOpenColorIO library
 IF(RV_TARGET_WINDOWS)
-  SET(_pyocio_lib_dir "${_lib_dir}/site-packages")
-  SET(_pyocio_libname PyOpenColorIO.pyd)
+  SET(_pyocio_lib_dir
+      "${_lib_dir}/site-packages"
+  )
+  SET(_pyocio_libname
+      PyOpenColorIO.pyd
+  )
 ELSE()
-  SET(_pyocio_lib_dir "${_lib_dir}/python${RV_DEPS_PYTHON_VERSION_SHORT}/site-packages")
-  SET(_pyocio_libname PyOpenColorIO.so)
+  SET(_pyocio_lib_dir
+      "${_lib_dir}/python${RV_DEPS_PYTHON_VERSION_SHORT}/site-packages"
+  )
+  SET(_pyocio_libname
+      PyOpenColorIO.so
+  )
 ENDIF()
-SET(_pyocio_lib "${_pyocio_lib_dir}/${_pyocio_libname}")
-SET(_pyocio_dest_dir ${RV_STAGE_LIB_DIR}/python${RV_DEPS_PYTHON_VERSION_SHORT})
+SET(_pyocio_lib
+    "${_pyocio_lib_dir}/${_pyocio_libname}"
+)
+SET(_pyocio_dest_dir
+    ${RV_STAGE_LIB_DIR}/python${RV_DEPS_PYTHON_VERSION_SHORT}
+)
 LIST(APPEND _byproducts "${_pyocio_lib}")
 
 #
@@ -90,8 +107,8 @@ LIST(APPEND _byproducts "${_pyocio_lib}")
 # The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
 LIST(APPEND _configure_options "-DOCIO_BUILD_TESTS=ON")
 LIST(APPEND _configure_options "-DOCIO_BUILD_GPU_TESTS=OFF")
-LIST(APPEND _configure_options "-DOCIO_BUILD_PYTHON=ON")  # This build PyOpenColorIO
-LIST(APPEND _configure_options "-DOCIO_USE_SSE=ON")  # SSE CPU performance optimizations
+LIST(APPEND _configure_options "-DOCIO_BUILD_PYTHON=ON") # This build PyOpenColorIO
+LIST(APPEND _configure_options "-DOCIO_USE_SSE=ON") # SSE CPU performance optimizations
 
 LIST(APPEND _configure_options "-DBOOST_ROOT=${RV_DEPS_BOOST_ROOT_DIR}")
 
@@ -99,10 +116,14 @@ LIST(APPEND _configure_options "-DBOOST_ROOT=${RV_DEPS_BOOST_ROOT_DIR}")
 LIST(APPEND _configure_options "-DPython_ROOT_DIR=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install")
 IF(RV_TARGET_WINDOWS)
   # Python path on Windows: python3.9.exe doesn't exist. Moreover, the executable needs the EXE extension otherwise find_package fails
-  SET(OCIO_PYTHON_PATH ${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${RV_DEPS_PYTHON_VERSION_MAJOR}.exe)
+  SET(OCIO_PYTHON_PATH
+      ${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${RV_DEPS_PYTHON_VERSION_MAJOR}.exe
+  )
   # To be added later to _configure_options as they are reset for Windows.
 ELSE()
-  SET(OCIO_PYTHON_PATH ${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${RV_DEPS_PYTHON_VERSION_SHORT})
+  SET(OCIO_PYTHON_PATH
+      ${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${RV_DEPS_PYTHON_VERSION_SHORT}
+  )
   LIST(APPEND _configure_options "-DPython_EXECUTABLE=${OCIO_PYTHON_PATH}")
 ENDIF()
 LIST(APPEND _configure_options "-DOCIO_PYTHON_VERSION=${RV_DEPS_PYTHON_VERSION_SHORT}")
@@ -122,19 +143,30 @@ LIST(APPEND _configure_options "-DImath_LIBRARY=${_imath_library}")
 LIST(APPEND _configure_options "-DImath_INCLUDE_DIR=${_imath_include_dir}/..")
 LIST(APPEND _configure_options "-DImath_ROOT=${RV_DEPS_IMATH_ROOT_DIR}")
 
-# OIIO target variables aren't defined yet as OCIO is included before OIIO
-# Moreover, normally giving OCIO the OIIO lib won't work since we build OCIO before OIIO.
-# OCIO is set to build missing dependencies so OCIO will use it's own OIIO lib.
-SET(_oiio_install_dir ${RV_DEPS_BASE_DIR}/RV_DEPS_OIIO/install)
+# OIIO target variables aren't defined yet as OCIO is included before OIIO Moreover, normally giving OCIO the OIIO lib won't work since we build OCIO before
+# OIIO. OCIO is set to build missing dependencies so OCIO will use it's own OIIO lib.
+SET(_oiio_install_dir
+    ${RV_DEPS_BASE_DIR}/RV_DEPS_OIIO/install
+)
 IF(RV_TARGET_DARWIN)
-  SET(_oiio_library "${_oiio_install_dir}/lib/libOpenImageIO.2.4.6.dylib")
+  SET(_oiio_library
+      "${_oiio_install_dir}/lib/libOpenImageIO.2.4.6.dylib"
+  )
 ELSEIF(RV_TARGET_LINUX)
-  SET(_oiio_library "${_oiio_install_dir}/lib64/libOpenImageIO.2.4.6.so")
+  SET(_oiio_library
+      "${_oiio_install_dir}/lib64/libOpenImageIO.2.4.6.so"
+  )
 ELSE()
-  SET(_oiio_library "${_oiio_install_dir}/lib/libOpenImageIO.2.4.6.dll")
+  SET(_oiio_library
+      "${_oiio_install_dir}/lib/libOpenImageIO.2.4.6.dll"
+  )
 ENDIF()
-SET(_oiio_include_dir "${_oiio_install_dir}/include")
-SET(_depends_oiio "")
+SET(_oiio_include_dir
+    "${_oiio_install_dir}/include"
+)
+SET(_depends_oiio
+    ""
+)
 
 MESSAGE(DEBUG "OCIO: _oiio_library='${_oiio_library}'")
 MESSAGE(DEBUG "OCIO: _oiio_include_dir='${_oiio_include_dir}'")
@@ -145,16 +177,15 @@ LIST(APPEND _configure_options "-DOPENIMAGEIO_ROOT_DIR=${_oiio_install_dir}")
 
 LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 
-# OCIO CMake Module FindOpenEXR.cmake file has issues with set_target_properties hence we set
-# APPS OFF. If you need Apps for a Test: hardcode _OpenEXR_TARGET_CREATE to FALSE in FindOpenEXR.cmake in OCIO
+# OCIO CMake Module FindOpenEXR.cmake file has issues with set_target_properties hence we set APPS OFF. If you need Apps for a Test: hardcode
+# _OpenEXR_TARGET_CREATE to FALSE in FindOpenEXR.cmake in OCIO
 LIST(APPEND _configure_options "-DOCIO_BUILD_APPS=OFF")
-
 
 IF(NOT RV_TARGET_WINDOWS)
   EXTERNALPROJECT_ADD(
     ${_target}
-      URL ${_download_url}
-      URL_MD5 ${_download_hash}
+    URL ${_download_url}
+    URL_MD5 ${_download_hash}
     DOWNLOAD_NAME ${_target}_${_version}.zip
     DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
@@ -175,14 +206,19 @@ ELSE()
   GET_FILENAME_COMPONENT(_vcpkg_path ${_vcpkg_location} DIRECTORY)
 
   # Some options are not multi-platform so we start clean.
-  SET(_configure_options "")
-  LIST(APPEND _configure_options
-    "-G ${CMAKE_GENERATOR}"                   # Not using Ninja: Ninja doesn't build due to Minizip wrong include style, VS uses search paths even for double-quotes includes.
+  SET(_configure_options
+      ""
+  )
+  LIST(
+    APPEND
+    _configure_options
+    "-G ${CMAKE_GENERATOR}" # Not using Ninja: Ninja doesn't build due to Minizip wrong include style, VS uses search paths even for double-quotes includes.
     "-DCMAKE_INSTALL_PREFIX=${_install_dir}"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-    "-DGLEW_ROOT=${_vcpkg_path}/packages/glew_x64-windows"   # Unknown if GLEW_ROOT, GLUT_ROOT and Oiio_ROOT is needed but at least: *they are used by OCIO in CMake*
-    "-DGLUT_ROOT=${_vcpkg_path}/packages/freeglut_x64-windows"   # However, not passing them doesn't seem to cause the build to fail.
-    "-DOpenImageIO_ROOT=${_oiio_install_dir}"         # And the Dev (cfuoco) said that we need to pass them; they are most likely needed for OCIO APPS
+    "-DGLEW_ROOT=${_vcpkg_path}/packages/glew_x64-windows" # Unknown if GLEW_ROOT, GLUT_ROOT and Oiio_ROOT is needed but at least: *they are used by OCIO in
+                                                           # CMake*
+    "-DGLUT_ROOT=${_vcpkg_path}/packages/freeglut_x64-windows" # However, not passing them doesn't seem to cause the build to fail.
+    "-DOpenImageIO_ROOT=${_oiio_install_dir}" # And the Dev (cfuoco) said that we need to pass them; they are most likely needed for OCIO APPS
     "-DOCIO_BUILD_PYTHON=ON"
     "-DOCIO_INSTALL_EXT_PACKAGES=ALL"
     "-DPython_EXECUTABLE=${OCIO_PYTHON_PATH}"
@@ -200,27 +236,25 @@ ELSE()
     "-B ${_build_dir}"
   )
 
-  LIST(APPEND _ocio_build_options
-    "--build"
-    "${_build_dir}"
-    "--config"
-    "${CMAKE_BUILD_TYPE}"
-    # "--parallel"    # parallel breaks minizip because Zlib is built before minizip and minizip depends on Zlib.
-    # "${_cpu_count}"   # Moreover, our Zlib isn't compatible with OCIO: tons of STD C++ missing symbols errors.
+  LIST(APPEND _ocio_build_options "--build" "${_build_dir}" "--config" "${CMAKE_BUILD_TYPE}"
+       # "--parallel"    # parallel breaks minizip because Zlib is built before minizip and minizip depends on Zlib. "${_cpu_count}"   # Moreover, our Zlib
+       # isn't compatible with OCIO: tons of STD C++ missing symbols errors.
   )
-  LIST(APPEND _ocio_install_options
+  LIST(
+    APPEND
+    _ocio_install_options
     "--install"
     "${_build_dir}"
     "--prefix"
     "${_install_dir}"
     "--config"
-    "${CMAKE_BUILD_TYPE}"   # for --config
+    "${CMAKE_BUILD_TYPE}" # for --config
   )
 
   EXTERNALPROJECT_ADD(
     ${_target}
-      URL ${_download_url}
-      URL_MD5 ${_download_hash}
+    URL ${_download_url}
+    URL_MD5 ${_download_hash}
     DOWNLOAD_NAME ${_target}_${_version}.zip
     DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
@@ -237,7 +271,9 @@ ELSE()
     USES_TERMINAL_BUILD TRUE
   )
 
-  SET(_vcpkg_manifest "${RV_PKGMANCONFIG_DIR}/ocio_vcpkg.json")
+  SET(_vcpkg_manifest
+      "${RV_PKGMANCONFIG_DIR}/ocio_vcpkg.json"
+  )
   EXTERNALPROJECT_ADD_STEP(
     ${_target} add_vcpkg_manifest
     COMMENT "Copying the VCPKG manifest"
@@ -255,23 +291,24 @@ ELSE()
   )
 ENDIF()
 
-IF(RV_TARGET_DARWIN OR
-    RV_TARGET_LINUX)
+IF(RV_TARGET_DARWIN
+   OR RV_TARGET_LINUX
+)
   ADD_CUSTOM_COMMAND(
-      TARGET ${_target}
-      POST_BUILD
+    TARGET ${_target}
+    POST_BUILD
     COMMENT "Copying PyOpenColorIO lib into '${RV_STAGE_PLUGINS_PYTHON_DIR}'."
     COMMAND ${CMAKE_COMMAND} -E copy ${_pyocio_lib} ${RV_STAGE_PLUGINS_PYTHON_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
-)
+  )
 ELSE()
   ADD_CUSTOM_COMMAND(
-      TARGET ${_target}
-      POST_BUILD
+    TARGET ${_target}
+    POST_BUILD
     COMMENT "Copying PyOpenColorIO lib into '${RV_STAGE_PLUGINS_PYTHON_DIR}'."
     COMMAND ${CMAKE_COMMAND} -E copy ${_pyocio_lib} ${RV_STAGE_PLUGINS_PYTHON_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy ${_ocio_win_sharedlib_path} ${RV_STAGE_PLUGINS_PYTHON_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ${_ocio_win_sharedlib_path} ${RV_STAGE_PLUGINS_PYTHON_DIR}
   )
 ENDIF()
 
@@ -292,8 +329,7 @@ IF(RV_TARGET_WINDOWS)
   )
 ENDIF()
 
-# It is required to force directory creation at configure time
-# otherwise CMake complains about importing a non-existing path
+# It is required to force directory creation at configure time otherwise CMake complains about importing a non-existing path
 FILE(MAKE_DIRECTORY ${_include_dir})
 TARGET_INCLUDE_DIRECTORIES(
   ocio::ocio

--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -209,6 +209,7 @@ ELSE()
   SET(_configure_options
       ""
   )
+  STRING(REPLACE "." "" PYTHON_VERSION_SHORT_NO_DOT ${RV_DEPS_PYTHON_VERSION_SHORT})
   LIST(
     APPEND
     _configure_options
@@ -220,9 +221,12 @@ ELSE()
     "-DGLUT_ROOT=${_vcpkg_path}/packages/freeglut_x64-windows" # However, not passing them doesn't seem to cause the build to fail.
     "-DOpenImageIO_ROOT=${_oiio_install_dir}" # And the Dev (cfuoco) said that we need to pass them; they are most likely needed for OCIO APPS
     "-DOCIO_BUILD_PYTHON=ON"
-    "-DOCIO_INSTALL_EXT_PACKAGES=ALL"
-    "-DPython_EXECUTABLE=${OCIO_PYTHON_PATH}"
-    "-DPython_ROOT_DIR=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install"
+    "-DOCIO_INSTALL_EXT_PACKAGES=ALL" # We should use the Default which is "MISSING" when OCIO removes OpenExr and find how to pass our own.
+    "-DPython_EXECUTABLE=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python.exe"
+    "-DPython_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install"
+    "-DPython_LIBRARY=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${PYTHON_VERSION_SHORT_NO_DOT}.lib" # Mandatory param: OCIO CMake code finds Python
+                                                                                                                # with this param
+    "-DPython_INCLUDE_DIR=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/include"
     "-DOCIO_PYTHON_VERSION=${RV_DEPS_PYTHON_VERSION_SHORT}"
     "-DBUILD_SHARED_LIBS=ON"
     "-DOCIO_BUILD_APPS=ON"

--- a/cmake/dependencies/tiff.cmake
+++ b/cmake/dependencies/tiff.cmake
@@ -95,28 +95,8 @@ IF(RV_TARGET_WINDOWS)
     COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/libtiff/tiffconf.h ${_include_dir}
     COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/libtiff/tif_config.h ${_include_dir}
     COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/libtiff/tif_dir.h ${_include_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/fax2ps.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/fax2tiff.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/fax2ps.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/fax2tiff.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/pal2rgb.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/ppm2tiff.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/raw2tiff.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/rgb2ycbcr.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/thumbnail.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiff2bw.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiff2pdf.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiff2ps.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiff2rgba.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffcmp.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffcp.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffcrop.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffdither.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffdump.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffinfo.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffmedian.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffset.exe ${_bin_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/tools/tiffsplit.exe ${_bin_dir}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${_base_dir}/src/tools ${_bin_dir}
+    COMMAND ${CMAKE_COMMAND} -E rm ${_bin_dir}/Makefile.am ${_bin_dir}/Makefile.vc ${_bin_dir}/Makefile.in ${_bin_dir}/CMakeLists.txt
   )
 
 ELSE()

--- a/cmake/dependencies/tiff.cmake
+++ b/cmake/dependencies/tiff.cmake
@@ -32,7 +32,11 @@ SET(_download_hash
 IF(NOT RV_TARGET_WINDOWS)
   # Mac/Linux: Use the unversionned .dylib.so LINK which points to the proper file (which has a diff version number) Mac/Linux: TIFF doesn't use a Postfix only
   # 'MSVC'.
-  RV_MAKE_STANDARD_LIB_NAME("tiff" "" "SHARED" "")
+  IF(RV_TARGET_DARWIN)
+    RV_MAKE_STANDARD_LIB_NAME("tiff" "5.3.0" "SHARED" "")
+  ELSE()
+    RV_MAKE_STANDARD_LIB_NAME("tiff" "" "SHARED" "")
+  ENDIF()
 ELSE()
   # The current CMake build code via NMake doesn't create a Debug lib named "libtiffd.lib"
   RV_MAKE_STANDARD_LIB_NAME("libtiff" "${_version}" "SHARED" "")
@@ -163,9 +167,8 @@ ELSE()
     TARGET ${_target}
     POST_BUILD
     COMMENT "Installing ${_target}'s missing headers"
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/build/libtiff/tif_config.h ${_include_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/libtiff/tiffiop.h ${_include_dir}
-    COMMAND ${CMAKE_COMMAND} -E copy ${_base_dir}/src/libtiff/tif_dir.h ${_include_dir}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_base_dir}/build/libtiff/tif_config.h ${_base_dir}/src/libtiff/tiffiop.h ${_base_dir}/src/libtiff/tif_dir.h
+            ${_include_dir}
   )
 ENDIF()
 

--- a/cmake/dependencies/yaml-cpp.cmake
+++ b/cmake/dependencies/yaml-cpp.cmake
@@ -9,52 +9,49 @@
 # Expose OCIO's own 'yaml_cpp' target replacing the legacy 'src/pub/yaml_cpp' folder.
 #
 # ##############################################################################################################################################################
-IF(RV_USE_OCIO_YAML_CPP)
-
-  ADD_LIBRARY(yaml_cpp STATIC IMPORTED GLOBAL)
-  ADD_DEPENDENCIES(yaml_cpp RV_DEPS_OCIO)
-  IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")
-    # Here the postfix is "d" and not "_d": the postfix inside OCIO is: "d".
-    SET(_debug_postfix
-        "d"
-    )
-    MESSAGE(DEBUG "Using debug postfix: '${_debug_postfix}'")
-  ELSE()
-    SET(_debug_postfix
-        ""
-    )
-  ENDIF()
-
-  IF(RV_TARGET_LINUX)
-    SET(_lib_dir
-        ${RV_DEPS_OCIO_DIST_DIR}/lib64
-    )
-  ELSE()
-    SET(_lib_dir
-        ${RV_DEPS_OCIO_DIST_DIR}/lib
-    )
-  ENDIF()
-
-  SET(_ocio_yaml_cpp_libpath
-      ${_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}yaml-cpp${_debug_postfix}${CMAKE_STATIC_LIBRARY_SUFFIX}
+ADD_LIBRARY(yaml_cpp STATIC IMPORTED GLOBAL)
+ADD_DEPENDENCIES(yaml_cpp RV_DEPS_OCIO)
+IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")
+  # Here the postfix is "d" and not "_d": the postfix inside OCIO is: "d".
+  SET(_debug_postfix
+      "d"
   )
-  SET_PROPERTY(
-    TARGET yaml_cpp
-    PROPERTY IMPORTED_LOCATION ${_ocio_yaml_cpp_libpath}
-  )
-
-  # It is required to force directory creation at configure time otherwise CMake complains about importing a non-existing path
-  SET(_yaml_cpp_include_dir
-      ${RV_DEPS_OCIO_DIST_DIR}/include
-  )
-  FILE(MAKE_DIRECTORY ${_yaml_cpp_include_dir})
-  TARGET_INCLUDE_DIRECTORIES(
-    yaml_cpp
-    INTERFACE ${_yaml_cpp_include_dir}
-  )
-
-  SET(RV_DEPS_YAML_CPP_VERSION
-      "0.7.0"
-      CACHE INTERNAL "" FORCE
+  MESSAGE(DEBUG "Using debug postfix: '${_debug_postfix}'")
+ELSE()
+  SET(_debug_postfix
+      ""
   )
 ENDIF()
+
+IF(RV_TARGET_LINUX)
+  SET(_lib_dir
+      ${RV_DEPS_OCIO_DIST_DIR}/lib64
+  )
+ELSE()
+  SET(_lib_dir
+      ${RV_DEPS_OCIO_DIST_DIR}/lib
+  )
+ENDIF()
+
+SET(_ocio_yaml_cpp_libpath
+    ${_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}yaml-cpp${_debug_postfix}${CMAKE_STATIC_LIBRARY_SUFFIX}
+)
+SET_PROPERTY(
+  TARGET yaml_cpp
+  PROPERTY IMPORTED_LOCATION ${_ocio_yaml_cpp_libpath}
+)
+
+# It is required to force directory creation at configure time otherwise CMake complains about importing a non-existing path
+SET(_yaml_cpp_include_dir
+    ${RV_DEPS_OCIO_DIST_DIR}/include
+)
+FILE(MAKE_DIRECTORY ${_yaml_cpp_include_dir})
+TARGET_INCLUDE_DIRECTORIES(
+  yaml_cpp
+  INTERFACE ${_yaml_cpp_include_dir}
+)
+
+SET(RV_DEPS_YAML_CPP_VERSION
+    "0.7.0"
+    CACHE INTERNAL "" FORCE
+)

--- a/cmake/install/pre_install_windows.cmake
+++ b/cmake/install/pre_install_windows.cmake
@@ -15,6 +15,16 @@ FUNCTION(before_copy_platform FILE_PATH RET_VAL)
     ENDIF()
   ENDIF()
 
+  # For <TIFF>/install/bin
+  IF(FILE_PATH MATCHES "\\.obj$"
+    OR FILE_PATH MATCHES "\\.c$")
+      SET(${RET_VAL}
+        "NO"
+        PARENT_SCOPE
+      )
+      RETURN()
+  ENDIF()
+
   SET(${RET_VAL}
       "YES"
       PARENT_SCOPE

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -187,7 +187,6 @@ OCIOIPNode::updateContext()
     if (Component* context = component("ocio_context"))
     {
         const Component::Container& props = context->properties();
-        //m_state->context = OCIO::Context::Create(); // destroys old one
 
         for (size_t i = 0; i < props.size(); i++)
         {
@@ -218,7 +217,8 @@ shaderLegal(const string& s)
 
     transform(s.begin(), s.end(), ns.begin(), op_shaderLegal);
 
-    // for any double underscore, OCIO will replace it with just one; do the same so our names align. (See: OCIO:GPUShaderDesc::setFunctionName)
+    // OCIO replaces any consecutive '_' with just one '_' (See: OCIO:GPUShaderDesc::setFunctionName)
+    // In order to keep the names aligned use: GPUShaderDesc::getFunctionName() to get the name OCIO uses to set RV's Shader Function and bind the parameters.
     ns = std::regex_replace(ns, std::regex("_+"), "_");   // one or more underscore: replace by only one.
     ns = std::regex_replace(ns, std::regex("_+$"), "");   // do not end by an underscore because the code will append another one
 
@@ -476,7 +476,7 @@ OCIOIPNode::evaluate(const Context& context)
                 shaderAdd3DLutAsParameter(glsl, m_lutSamplerName);
             }
 
-            m_state->function = new Shader::Function(shaderName.str(), 
+            m_state->function = new Shader::Function(shaderDesc->getFunctionName(),
                                                      glsl,
                                                      Shader::Function::Color,
                                                      1);
@@ -485,7 +485,7 @@ OCIOIPNode::evaluate(const Context& context)
             if (Shader::debuggingType() != Shader::NoDebugInfo)
             {
                 cerr << "OCIONode: " << name() << " new shaderID " << shaderCacheID << endl <<
-                        "OCIONode:     new Shader '" << shaderName.str() << "':" << endl << glsl << endl;
+                        "OCIONode:     new Shader '" << shaderDesc->getFunctionName() << "':" << endl << glsl << endl;
             }
         }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

Code improvements based on Feedback for OCIO and TIFF on both Mac and Windows

### Describe the reason for the change.

OCIO on Windows was failing to build due to Python.

### Describe what you have tested and on which operating system.

Tested on MacOS Ventura, Windows 11 and Rocky Linux.

### Add a list of changes, and note any that might need special attention during the review.

Removing somewhat duplicated variable value for GPUShaderName in OCIO.
Optimizing TIFF Windows copy in POST_BUILD by using exclusion rules
Fixing Mac rebuilding without any changes for TIFF

### If possible, provide screenshots.